### PR TITLE
Add If let capabilities to rxSwift

### DIFF
--- a/ComposableArchitecture.xcodeproj/project.pbxproj
+++ b/ComposableArchitecture.xcodeproj/project.pbxproj
@@ -1096,7 +1096,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.4.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					Combine,
@@ -1132,7 +1132,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.4.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					Combine,
@@ -1368,7 +1368,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.4.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1404,7 +1404,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.4.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					SwiftUI,
@@ -1440,7 +1440,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.4.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					Combine,
@@ -1476,7 +1476,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.2;
+				MARKETING_VERSION = 0.4.0;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					Combine,

--- a/ComposableArchitecture.xcodeproj/project.pbxproj
+++ b/ComposableArchitecture.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		41364CC9248C6028007EBA46 /* Reducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364C9A248C6028007EBA46 /* Reducer.swift */; };
 		41364CCA248C6028007EBA46 /* Publisher+asObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364C9C248C6028007EBA46 /* Publisher+asObservable.swift */; };
 		41364CCB248C6028007EBA46 /* Observable+asPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364C9D248C6028007EBA46 /* Observable+asPublisher.swift */; };
-		41364CCE248C6028007EBA46 /* IfLetUIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364CA2248C6028007EBA46 /* IfLetUIKit.swift */; };
+		41364CCE248C6028007EBA46 /* IfLetUIKit+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364CA2248C6028007EBA46 /* IfLetUIKit+Combine.swift */; };
 		41364CCF248C6028007EBA46 /* ReducerDebugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364CA4248C6028007EBA46 /* ReducerDebugging.swift */; };
 		41364CD0248C6028007EBA46 /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364CA6248C6028007EBA46 /* Diff.swift */; };
 		41364CD1248C6028007EBA46 /* Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41364CA7248C6028007EBA46 /* Deprecations.swift */; };
@@ -112,6 +112,7 @@
 		4176B35524A9033B003D6097 /* RxRelay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4162603F248D2E14003FCAA8 /* RxRelay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4176B35624A9033B003D6097 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41626041248D2E14003FCAA8 /* RxSwift.framework */; };
 		4176B35724A9033B003D6097 /* RxSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 41626041248D2E14003FCAA8 /* RxSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BEC93A4424B8EE0B00D8082D /* IfLetUIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC93A4324B8EE0B00D8082D /* IfLetUIKit.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -222,7 +223,7 @@
 		41364C9A248C6028007EBA46 /* Reducer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reducer.swift; sourceTree = "<group>"; };
 		41364C9C248C6028007EBA46 /* Publisher+asObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publisher+asObservable.swift"; sourceTree = "<group>"; };
 		41364C9D248C6028007EBA46 /* Observable+asPublisher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+asPublisher.swift"; sourceTree = "<group>"; };
-		41364CA2248C6028007EBA46 /* IfLetUIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IfLetUIKit.swift; sourceTree = "<group>"; };
+		41364CA2248C6028007EBA46 /* IfLetUIKit+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "IfLetUIKit+Combine.swift"; sourceTree = "<group>"; };
 		41364CA4248C6028007EBA46 /* ReducerDebugging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReducerDebugging.swift; sourceTree = "<group>"; };
 		41364CA6248C6028007EBA46 /* Diff.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Diff.swift; sourceTree = "<group>"; };
 		41364CA7248C6028007EBA46 /* Deprecations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deprecations.swift; sourceTree = "<group>"; };
@@ -302,6 +303,7 @@
 		4176B33124A901ED003D6097 /* ComposableCoreMotionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ComposableCoreMotionTests.swift; sourceTree = "<group>"; };
 		4176B33724A90209003D6097 /* ComposableCoreMotionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ComposableCoreMotionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4176B33B24A90209003D6097 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BEC93A4324B8EE0B00D8082D /* IfLetUIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IfLetUIKit.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -456,7 +458,8 @@
 		41364CA1248C6028007EBA46 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				41364CA2248C6028007EBA46 /* IfLetUIKit.swift */,
+				BEC93A4324B8EE0B00D8082D /* IfLetUIKit.swift */,
+				41364CA2248C6028007EBA46 /* IfLetUIKit+Combine.swift */,
 			);
 			path = UIKit;
 			sourceTree = "<group>";
@@ -984,10 +987,11 @@
 				4176B30824A8E1AA003D6097 /* UIScheduler.swift in Sources */,
 				41364CE0248C6028007EBA46 /* ViewStore.swift in Sources */,
 				41364CD0248C6028007EBA46 /* Diff.swift in Sources */,
-				41364CCE248C6028007EBA46 /* IfLetUIKit.swift in Sources */,
+				41364CCE248C6028007EBA46 /* IfLetUIKit+Combine.swift in Sources */,
 				41364CDC248C6028007EBA46 /* Store+Combine.swift in Sources */,
 				41364CD4248C6028007EBA46 /* Debug.swift in Sources */,
 				41364CCB248C6028007EBA46 /* Observable+asPublisher.swift in Sources */,
+				BEC93A4424B8EE0B00D8082D /* IfLetUIKit.swift in Sources */,
 				4176B30924A8E1AA003D6097 /* ImmediateScheduler.swift in Sources */,
 				41364CDD248C6028007EBA46 /* Effect+Timer.swift in Sources */,
 				4176B2FC24A8D18E003D6097 /* Observable+onCompletion.swift in Sources */,
@@ -1360,7 +1364,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					Combine,
@@ -1394,7 +1398,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.3.1;
+				MARKETING_VERSION = 0.3.2;
 				OTHER_LDFLAGS = (
 					"-weak_framework",
 					Combine,

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit+Combine.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit+Combine.swift
@@ -1,0 +1,73 @@
+#if canImport(Combine)
+import Combine
+
+@available(iOS 13, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+extension Store {
+  /// Subscribes to updates when a store containing optional state goes from `nil` to non-`nil` or
+  /// non-`nil` to `nil`.
+  ///
+  /// This is useful for handling navigation in UIKit. The state for a screen that you want to
+  /// navigate to can be held as an optional value in the parent, and when that value switches
+  /// from `nil` to non-`nil` you want to trigger a navigation and hand the detail view a `Store`
+  /// whose domain has been scoped to just that feature:
+  ///
+  ///     class MasterViewController: UIViewController {
+  ///       let store: Store<MasterState, MasterAction>
+  ///       var cancellables: Set<AnyCancellable> = []
+  ///       ...
+  ///       func viewDidLoad() {
+  ///         ...
+  ///         self.store
+  ///           .scope(state: \.optionalDetail, action: MasterAction.detail)
+  ///           .ifLet(
+  ///             then: { [weak self] detailStore in
+  ///               self?.navigationController?.pushViewController(
+  ///                 DetailViewController(store: detailStore),
+  ///                 animated: true
+  ///               )
+  ///             },
+  ///             else: { [weak self] in
+  ///               guard let self = self else { return }
+  ///               self.navigationController?.popToViewController(self, animated: true)
+  ///             }
+  ///           )
+  ///           .store(in: &self.cancellables)
+  ///       }
+  ///     }
+  ///
+  /// - Parameters:
+  ///   - unwrap: A function that is called with a store of non-optional state whenever the store's
+  ///     optional state goes from `nil` to non-`nil`.
+  ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
+  ///     `nil`.
+  /// - Returns: A cancellable associated with the underlying subscription.
+  public func ifLet<Wrapped>(
+    then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
+    else: @escaping () -> Void
+  ) -> Cancellable where State == Wrapped? {
+    self
+      .scope(
+        state: { state in
+          state
+            .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
+            .handleEvents(receiveOutput: { if $0 == nil { `else`() } })
+            .compactMap { $0 }
+        },
+        action: { $0 }
+      )
+      .sink(receiveValue: unwrap)
+  }
+
+  /// An overload of `ifLet(then:else:)` for the times that you do not want to handle the `else`
+  /// case.
+  ///
+  /// - Parameter unwrap: A function that is called with a store of non-optional state whenever the
+  ///   store's optional state goes from `nil` to non-`nil`.
+  /// - Returns: A cancellable associated with the underlying subscription.
+  public func ifLet<Wrapped>(
+    then unwrap: @escaping (Store<Wrapped, Action>) -> Void
+  ) -> Cancellable where State == Wrapped? {
+    self.ifLet(then: unwrap, else: {})
+  }
+}
+#endif

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -1,73 +1,108 @@
-#if canImport(Combine)
-import Combine
+//
+//  ComposableArchitecture+utils.swift
+//  pureairconnect
+//
+//  Created by sebastien on 09/07/2020.
+//  Copyright © 2020 Groupe SEB. All rights reserved.
+//
 
-@available(iOS 13, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+import Foundation
+import RxSwift
+import ComposableArchitecture
+
 extension Store {
-  /// Subscribes to updates when a store containing optional state goes from `nil` to non-`nil` or
-  /// non-`nil` to `nil`.
-  ///
-  /// This is useful for handling navigation in UIKit. The state for a screen that you want to
-  /// navigate to can be held as an optional value in the parent, and when that value switches
-  /// from `nil` to non-`nil` you want to trigger a navigation and hand the detail view a `Store`
-  /// whose domain has been scoped to just that feature:
-  ///
-  ///     class MasterViewController: UIViewController {
-  ///       let store: Store<MasterState, MasterAction>
-  ///       var cancellables: Set<AnyCancellable> = []
-  ///       ...
-  ///       func viewDidLoad() {
-  ///         ...
-  ///         self.store
-  ///           .scope(state: \.optionalDetail, action: MasterAction.detail)
-  ///           .ifLet(
-  ///             then: { [weak self] detailStore in
-  ///               self?.navigationController?.pushViewController(
-  ///                 DetailViewController(store: detailStore),
-  ///                 animated: true
-  ///               )
-  ///             },
-  ///             else: { [weak self] in
-  ///               guard let self = self else { return }
-  ///               self.navigationController?.popToViewController(self, animated: true)
-  ///             }
-  ///           )
-  ///           .store(in: &self.cancellables)
-  ///       }
-  ///     }
-  ///
-  /// - Parameters:
-  ///   - unwrap: A function that is called with a store of non-optional state whenever the store's
-  ///     optional state goes from `nil` to non-`nil`.
-  ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
-  ///     `nil`.
-  /// - Returns: A cancellable associated with the underlying subscription.
-  public func ifLet<Wrapped>(
-    then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
-    else: @escaping () -> Void
-  ) -> Cancellable where State == Wrapped? {
-    self
-      .scope(
-        state: { state in
-          state
-            .removeDuplicates(by: { ($0 != nil) == ($1 != nil) })
-            .handleEvents(receiveOutput: { if $0 == nil { `else`() } })
-            .compactMap { $0 }
-        },
-        action: { $0 }
-      )
-      .sink(receiveValue: unwrap)
-  }
-
-  /// An overload of `ifLet(then:else:)` for the times that you do not want to handle the `else`
-  /// case.
-  ///
-  /// - Parameter unwrap: A function that is called with a store of non-optional state whenever the
-  ///   store's optional state goes from `nil` to non-`nil`.
-  /// - Returns: A cancellable associated with the underlying subscription.
-  public func ifLet<Wrapped>(
-    then unwrap: @escaping (Store<Wrapped, Action>) -> Void
-  ) -> Cancellable where State == Wrapped? {
-    self.ifLet(then: unwrap, else: {})
-  }
+    /// Subscribes to updates when a store containing optional state goes from `nil` to non-`nil` or
+    /// non-`nil` to `nil`.
+    ///
+    /// This is useful for handling navigation in UIKit. The state for a screen that you want to
+    /// navigate to can be held as an optional value in the parent, and when that value switches
+    /// from `nil` to non-`nil` you want to trigger a navigation and hand the detail view a `Store`
+    /// whose domain has been scoped to just that feature:
+    ///
+    ///     class MasterViewController: UIViewController {
+    ///       let store: Store<MasterState, MasterAction>
+    ///       var cancellables: Set<AnyCancellable> = []
+    ///       ...
+    ///       func viewDidLoad() {
+    ///         ...
+    ///         self.store
+    ///           .scope(state: \.optionalDetail, action: MasterAction.detail)
+    ///           .ifLet(
+    ///             then: { [weak self] detailStore in
+    ///               self?.navigationController?.pushViewController(
+    ///                 DetailViewController(store: detailStore),
+    ///                 animated: true
+    ///               )
+    ///             },
+    ///             else: { [weak self] in
+    ///               guard let self = self else { return }
+    ///               self.navigationController?.popToViewController(self, animated: true)
+    ///             }
+    ///           )
+    ///           .store(in: &self.cancellables)
+    ///       }
+    ///     }
+    ///
+    /// - Parameters:
+    ///   - unwrap: A function that is called with a store of non-optional state whenever the store's
+    ///     optional state goes from `nil` to non-`nil`.
+    ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
+    ///     `nil`.
+    /// - Returns: A Disposable associated with the underlying subscription.
+    public func ifLet<Wrapped>(
+      then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
+      else: @escaping () -> Void
+    ) -> Disposable where State == Wrapped? {
+        self.scope { (state: Observable<Wrapped?>) in
+            state
+                .distinctUntilChanged { ($0 != nil) == ($1 != nil) }
+                .do(onNext: {
+                    if $0 == nil {
+                        `else`()
+                    }
+                })
+                .compactMap { $0 }
+        }.subscribe(onNext: unwrap)
+    }
+    
+    /// An overload of `ifLet(then:else:)` for the times that you do not want to handle the `else`
+    /// case.
+    ///
+    /// - Parameter unwrap: A function that is called with a store of non-optional state whenever the
+    ///   store's optional state goes from `nil` to non-`nil`.
+    /// - Returns: A Disposable associated with the underlying subscription.
+    public func ifLet<Wrapped>(
+      then unwrap: @escaping (Store<Wrapped, Action>) -> Void
+    ) -> Disposable where State == Wrapped? {
+      self.ifLet(then: unwrap, else: {})
+    }
 }
-#endif
+
+
+extension Store where State: Equatable {
+    
+    /// Subscribes to updates when a store containing a state goes change from or to the given Condition or
+    /// condition = true to condition = false.
+    /// - Parameters:
+    ///   - condition: the condition that you want to observe
+    ///   - then: closure that is executed when the condition is true
+    ///   - else: closure that is executed when the condition is false
+    /// - Returns: A Disposable associated with the underlying subscription.
+    public func `if`(
+        condition: @escaping (State) -> Bool,
+        then: @escaping (Store<State, Action>) -> Void,
+        else: @escaping () -> Void = {}
+    ) -> Disposable{
+        self.scope { (observableState: Observable<State>) in
+            observableState
+                .distinctUntilChanged()
+                .do(onNext: {
+                    print("test if new message : \($0)")
+                    if !condition($0) {
+                        `else`()
+                    }
+                })
+                .filter(condition)
+        }.subscribe(onNext: then)
+    }
+}

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -73,25 +73,3 @@ extension Store {
     ifLet(then: unwrap, else: {})
   }
 }
-
-extension Store where State: Equatable {
-  
-  /// Subscribes to updates when condition on state is toggled.
-  /// - Parameters:
-  ///   - condition: the condition that you want to observe
-  ///   - then: closure that is executed when the condition is true
-  ///   - else: closure that is executed when the condition is false
-  /// - Returns: A Disposable associated with the underlying subscription.
-  public func `if`(
-    condition: @escaping (State) -> Bool,
-    then: @escaping (Store<State, Action>) -> Void,
-    else: @escaping () -> Void = {}
-  ) -> Disposable{
-    scope { (observableState: Observable<State>) in
-      observableState
-        .distinctUntilChanged()
-        .do(onNext: { if !condition($0) { `else`() } })
-        .filter(condition)
-    }.subscribe(onNext: then)
-  }
-}

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -8,101 +8,90 @@
 
 import Foundation
 import RxSwift
-import ComposableArchitecture
 
 extension Store {
-    /// Subscribes to updates when a store containing optional state goes from `nil` to non-`nil` or
-    /// non-`nil` to `nil`.
-    ///
-    /// This is useful for handling navigation in UIKit. The state for a screen that you want to
-    /// navigate to can be held as an optional value in the parent, and when that value switches
-    /// from `nil` to non-`nil` you want to trigger a navigation and hand the detail view a `Store`
-    /// whose domain has been scoped to just that feature:
-    ///
-    ///     class MasterViewController: UIViewController {
-    ///       let store: Store<MasterState, MasterAction>
-    ///       var cancellables: Set<AnyCancellable> = []
-    ///       ...
-    ///       func viewDidLoad() {
-    ///         ...
-    ///         self.store
-    ///           .scope(state: \.optionalDetail, action: MasterAction.detail)
-    ///           .ifLet(
-    ///             then: { [weak self] detailStore in
-    ///               self?.navigationController?.pushViewController(
-    ///                 DetailViewController(store: detailStore),
-    ///                 animated: true
-    ///               )
-    ///             },
-    ///             else: { [weak self] in
-    ///               guard let self = self else { return }
-    ///               self.navigationController?.popToViewController(self, animated: true)
-    ///             }
-    ///           )
-    ///           .store(in: &self.cancellables)
-    ///       }
-    ///     }
-    ///
-    /// - Parameters:
-    ///   - unwrap: A function that is called with a store of non-optional state whenever the store's
-    ///     optional state goes from `nil` to non-`nil`.
-    ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
-    ///     `nil`.
-    /// - Returns: A Disposable associated with the underlying subscription.
-    public func ifLet<Wrapped>(
-      then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
-      else: @escaping () -> Void
-    ) -> Disposable where State == Wrapped? {
-        self.scope { (state: Observable<Wrapped?>) in
-            state
-                .distinctUntilChanged { ($0 != nil) == ($1 != nil) }
-                .do(onNext: {
-                    if $0 == nil {
-                        `else`()
-                    }
-                })
-                .compactMap { $0 }
-        }.subscribe(onNext: unwrap)
+  /// Subscribes to updates when a store containing optional state goes from `nil` to non-`nil` or
+  /// non-`nil` to `nil`.
+  ///
+  /// This is useful for handling navigation in UIKit. The state for a screen that you want to
+  /// navigate to can be held as an optional value in the parent, and when that value switches
+  /// from `nil` to non-`nil` you want to trigger a navigation and hand the detail view a `Store`
+  /// whose domain has been scoped to just that feature:
+  ///
+  ///     class MasterViewController: UIViewController {
+  ///       let store: Store<MasterState, MasterAction>
+  ///       let disposeBag = DisposeBag()
+  ///       ...
+  ///       func viewDidLoad() {
+  ///         ...
+  ///         self.store
+  ///           .scope(state: \.optionalDetail, action: MasterAction.detail)
+  ///           .ifLet(
+  ///             then: { [weak self] detailStore in
+  ///               self?.navigationController?.pushViewController(
+  ///                 DetailViewController(store: detailStore),
+  ///                 animated: true
+  ///               )
+  ///             },
+  ///             else: { [weak self] in
+  ///               guard let self = self else { return }
+  ///               self.navigationController?.popToViewController(self, animated: true)
+  ///             }
+  ///           )
+  ///           .disposed(by: disposeBag)
+  ///       }
+  ///     }
+  ///
+  /// - Parameters:
+  ///   - unwrap: A function that is called with a store of non-optional state whenever the store's
+  ///     optional state goes from `nil` to non-`nil`.
+  ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
+  ///     `nil`.
+  /// - Returns: A Disposable associated with the underlying subscription.
+  public func ifLet<Wrapped>(
+    then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
+    else: @escaping () -> Void
+  ) -> Disposable where State == Wrapped? {
+    scope { (state: Observable<Wrapped?>) in
+      state
+        .distinctUntilChanged { ($0 != nil) == ($1 != nil) }
+        .do(onNext: { if $0 == nil { `else`() } })
+        .compactMap { $0 }
     }
-    
-    /// An overload of `ifLet(then:else:)` for the times that you do not want to handle the `else`
-    /// case.
-    ///
-    /// - Parameter unwrap: A function that is called with a store of non-optional state whenever the
-    ///   store's optional state goes from `nil` to non-`nil`.
-    /// - Returns: A Disposable associated with the underlying subscription.
-    public func ifLet<Wrapped>(
-      then unwrap: @escaping (Store<Wrapped, Action>) -> Void
-    ) -> Disposable where State == Wrapped? {
-      self.ifLet(then: unwrap, else: {})
-    }
+    .subscribe(onNext: unwrap)
+  }
+  
+  /// An overload of `ifLet(then:else:)` for the times that you do not want to handle the `else`
+  /// case.
+  ///
+  /// - Parameter unwrap: A function that is called with a store of non-optional state whenever the
+  ///   store's optional state goes from `nil` to non-`nil`.
+  /// - Returns: A Disposable associated with the underlying subscription.
+  public func ifLet<Wrapped>(
+    then unwrap: @escaping (Store<Wrapped, Action>) -> Void
+  ) -> Disposable where State == Wrapped? {
+    ifLet(then: unwrap, else: {})
+  }
 }
 
-
 extension Store where State: Equatable {
-    
-    /// Subscribes to updates when a store containing a state goes change from or to the given Condition or
-    /// condition = true to condition = false.
-    /// - Parameters:
-    ///   - condition: the condition that you want to observe
-    ///   - then: closure that is executed when the condition is true
-    ///   - else: closure that is executed when the condition is false
-    /// - Returns: A Disposable associated with the underlying subscription.
-    public func `if`(
-        condition: @escaping (State) -> Bool,
-        then: @escaping (Store<State, Action>) -> Void,
-        else: @escaping () -> Void = {}
-    ) -> Disposable{
-        self.scope { (observableState: Observable<State>) in
-            observableState
-                .distinctUntilChanged()
-                .do(onNext: {
-                    print("test if new message : \($0)")
-                    if !condition($0) {
-                        `else`()
-                    }
-                })
-                .filter(condition)
-        }.subscribe(onNext: then)
-    }
+  
+  /// Subscribes to updates when condition on state is toggled.
+  /// - Parameters:
+  ///   - condition: the condition that you want to observe
+  ///   - then: closure that is executed when the condition is true
+  ///   - else: closure that is executed when the condition is false
+  /// - Returns: A Disposable associated with the underlying subscription.
+  public func `if`(
+    condition: @escaping (State) -> Bool,
+    then: @escaping (Store<State, Action>) -> Void,
+    else: @escaping () -> Void = {}
+  ) -> Disposable{
+    scope { (observableState: Observable<State>) in
+      observableState
+        .distinctUntilChanged()
+        .do(onNext: { if !condition($0) { `else`() } })
+        .filter(condition)
+    }.subscribe(onNext: then)
+  }
 }


### PR DESCRIPTION
ajout des méthodes if let UIKit en RxSwift, ce qui permet de faire des choses de ce genre : 

```Swift
self.store
            .scope(state: \.history.applianceHistory,
                   action: { AppAction.history(.applianceHistoryAction($0)) })
            .ifLet(then: { [weak self] (store) in
                guard let strongSelf = self else { return }
                // push controller
                let presentable = strongSelf.presentablesFactory.buildHistory(store: store)
                strongSelf.router.push(presentable: presentable,
                                       displayBackButton: true,
                                       onPop: {
                    // here we handle the case where we use the swipe to go back
                    // by doing so, we reinitialize the state
                    strongSelf.viewStore.send(.history(.applianceHistoryAction(.goBackTapped)))
                })
            }, else: { [weak self] in
                    // here we handle the case where we tapped on the back button in the screen
                    // by doing so, we comply with the state and we pop the controller out
                    self?.router.popPresentable(executePopClosures: false)
            }).disposed(by: disposeBag)
```

en gros quand le state n'est plus nil, automatiquement ça va pusher le controller, et ça va le poser quand il repasse à nil